### PR TITLE
fix(github): adding github templates and license

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report 🐛
+about: Something isn't working as expected? Here is the right place to report.
+labels: bug
+assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn, RaphaelAmadeu, jacobottesen-dgc
+---
+
+<!-- Feel free to remove sections that aren't relevant.
+
+## Title line template: [Title]: Brief description
+
+-->
+
+## Detailed description
+
+> Describe in detail the issue you're having.
+
+> Is this a feature request (new component, new icon), a bug, or a general
+> issue?
+
+> Is this issue related to a specific component?
+
+> What did you expect to happen? What happened instead? What would you like to
+> see changed?
+
+> What browser are you working in?
+
+> What version of the NextJS template are you using?
+
+> What offering/product do you work on? Any pressing ship or release dates we
+> should be aware of?
+
+## Steps to reproduce the issue
+
+1. Step one
+2. Step two
+3. Step three
+4. etc.
+
+## Additional information
+
+- Screenshots or code
+- Notes

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request 💡
+about: Suggest a new idea for the project.
+title: ""
+labels: Feature request
+assignees: jeffchew, wonilsuhibm, RaphaelAmadeu, jacobottesen-dgc
+---
+
+<!-- replace _{{...}}_ with your own words -->
+
+### The problem
+
+_{{A clear and concise description of what the problem this new feature is trying to solve. (ex. I'm always frustrated when...)}}_
+
+### The solution
+
+_{{A clear and concise description of what you want to happen}}_
+
+### Additional information
+
+_{{Please provide any additional information or resources for reference}}_
+
+- _{{user research}}_
+- _{{user insights}}_
+- _{{user metrics}}_

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,30 @@
+---
+name: Question 🤔
+about: Usage question or discussion about the IBM.com Library.
+labels: question
+assignees: jeffchew, wonilsuhibm, ljcarot, RobertaJHahn, RaphaelAmadeu, jacobottesen-dgc
+---
+
+<!--
+
+Hi there! 👋 Hope everything is going okay using projects from the IBM Digital
+Design System team. It looks like you might have a question about our work, so
+we wanted to share a couple resources that you could use if you haven't tried
+them yet 🙂.
+
+If you're an IBMer, we have a couple of Slack channels available across all IBM
+Workspaces:
+
+- #ibm-digital-design for questions about the IBM.com Library
+- #carbon-design-system for questions about the Carbon Design System
+
+If these resources don't work out, help us out by filling out a couple of
+details below!
+
+-->
+
+## Summary
+
+## Relevant information
+
+<!-- Provide as much useful information as you can -->

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,0 +1,41 @@
+---
+name: "User story \U0001F5E3"
+about: Write a user story to begin solving their needs.
+title: ""
+labels: ""
+assignees: ""
+---
+
+<!-- Avoid any type of solutions in this user story -->
+<!-- replace _{{...}}_ with your own words or remove -->
+
+#### User Story
+
+<!-- {{Provide a detailed description of the user's need here, but avoid any type of solutions}} -->
+
+> As a `[user role below]`:
+
+> I need to:
+
+> so that I can:
+
+#### Additional information
+
+<!--  {{Please provide any additional information or resources for reference}} -->
+
+- _{{user research}}_
+- _{{user insights}}_
+- _{{user metrics}}_
+
+#### Acceptance criteria
+
+- [ ] _{{State acceptance criteria}}_
+- [ ] _{{State another}}_
+- [ ] _{{And another}}_
+
+<!-- Consider the following when writing Acceptance criteria for this story. -->
+<!-- *** Each product backlog item or user story should have at least one Acceptance criteria. -->
+<!-- *** Acceptance criteria defines a deliverable that can be completed in a single sprint -->
+<!-- *** Each Acceptance criterion is independently testable. -->
+<!-- *** Include functional as well as non-functional criteria – when relevant. -->
+<!-- *** Team members write Acceptance criteria and the Product Owner verifies it. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+### Related Ticket(s)
+
+{{Provide url(s) to the related ticket(s) that this pull request addresses}}
+
+### Description
+
+{{Add a human-readable description / detail summary of what the PR is changing and any details around how and why}}
+
+{{If applicable, include a screenshot indicating an example or examples of what the PR is changing in the application}}
+
+### Changelog
+
+**New**
+
+- {{new thing}}
+
+**Changed**
+
+- {{changed thing}}
+
+**Removed**
+
+- {{removed thing}}

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 3
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - 'severity 1'
+  - 'priority: high'
+  - 'icebox'
+# Label to use when marking an issue as stale
+staleLabel: inactive
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  We've marked this issue as stale because there hasn't been any activity for 60 days.
+  If there's no further activity on this issue in the next three days then we'll close it. You can
+  keep the conversation going with just a short comment. Thanks for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  As there's been no activity since this issue was marked as stale, we are auto-closing it.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 IBM Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
   "name": "ibm-dotcom-library-nextjs-template",
   "private": true,
+  "version": "0.0.0",
+  "repository": "git@github.com:carbon-design-system/ibm-dotcom-library-nextjs-template.git",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "12.x"
+  },
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
This adds a number of github templates for better support of this repository. 

The LICENSE file was also missing, so those details were added.