### PR TITLE
chore(dependabot): updating resolution of serialize-javascript

### DIFF
--- a/components/altlang.js
+++ b/components/altlang.js
@@ -19,9 +19,10 @@ const _rootPath = process.env.ALTLANG_ROOT_PATH || "/";
  */
 const _renderAltLangs = () => {
   let langs = [];
-  altlangs.forEach((alt) => {
+  altlangs.forEach((alt, i) => {
     langs.push(
       <link
+        key={i}
         rel="alternate"
         hrefLang={`${alt.lc}-${alt.cc}`}
         href={`${_rootPath}?cc=${alt.cc}&lc=${alt.lc}`}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "update-latest": "yarn upgrade @carbon/ibmdotcom-react@latest && yarn upgrade @carbon/ibmdotcom-styles@latest"
   },
   "dependencies": {
-    "@carbon/ibmdotcom-react": "^1.10.2-rc.1",
+    "@carbon/ibmdotcom-react": "^1.10.2-rc.2",
     "@carbon/ibmdotcom-styles": "^1.10.1-rc.0",
     "@carbon/icons-react": "^10.9.1",
     "@carbon/pictograms-react": "^10.9.0",
@@ -54,6 +54,6 @@
     "webpack": "^4.41.5"
   },
   "resolutions": {
-    "serialize-javascript": ">= 2.1.2"
+    "serialize-javascript": ">= 3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,13 +1261,13 @@
     "@carbon/import-once" "^10.3.0"
     "@carbon/layout" "^10.12.0"
 
-"@carbon/ibmdotcom-react@^1.10.2-rc.1":
-  version "1.10.2-rc.1"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-react/-/ibmdotcom-react-1.10.2-rc.1.tgz#8c50314abcd0de89b840815c8c5fffd4bf08d54b"
-  integrity sha512-bDqHK9wj60s9eJF2DS87i4Z6Z/0X4cVbiOMmW3I14x1YG+2NmuXo0LTy0clSGtGFmSniGscaNYxhHBA2vyUMJQ==
+"@carbon/ibmdotcom-react@^1.10.2-rc.2":
+  version "1.10.2-rc.2"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-react/-/ibmdotcom-react-1.10.2-rc.2.tgz#f1d30640b641bb60bfa54a956c595d68ab11d305"
+  integrity sha512-Y0lHgAIg9Duy3m2gt6z2jYw2/yBGQ3WLRGYWGINonb1exmzyLBzFDk70vfMzjKtzW2PMtnMyF6Dky2y9xoyGkA==
   dependencies:
     "@babel/runtime" "^7.5.5"
-    "@carbon/ibmdotcom-services" "1.10.2-rc.1"
+    "@carbon/ibmdotcom-services" "1.10.2-rc.2"
     "@carbon/ibmdotcom-styles" "1.10.1"
     "@carbon/ibmdotcom-utilities" "1.10.2-rc.1"
     autosuggest-highlight "^3.1.1"
@@ -1278,10 +1278,10 @@
     react-autosuggest "^9.4.3"
     window-or-global "^1.0.1"
 
-"@carbon/ibmdotcom-services@1.10.2-rc.1":
-  version "1.10.2-rc.1"
-  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-services/-/ibmdotcom-services-1.10.2-rc.1.tgz#d8c4541693940c6f4e476c7a158e66b53cad6282"
-  integrity sha512-inehSgfov0sDRbCsIwlnvLmdTiiS9hBR+xeAukKNrx/+kwUtZg2iYbZG8bJEgI+k9XukQlApoUA+QjTNwJvfVQ==
+"@carbon/ibmdotcom-services@1.10.2-rc.2":
+  version "1.10.2-rc.2"
+  resolved "https://registry.yarnpkg.com/@carbon/ibmdotcom-services/-/ibmdotcom-services-1.10.2-rc.2.tgz#d4d8ab254861482129d7fb3634c7e0500ce4144a"
+  integrity sha512-qoburfK2dSrzQicvGUIMymU6Tn1rVriQMpD38iML6Izs8LREw/bX7dY32uyudUTGc0WN9DnyZeKIMSqFTqraKw==
   dependencies:
     "@carbon/ibmdotcom-utilities" "1.10.2-rc.1"
     axios "^0.19.0"
@@ -3962,15 +3962,6 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
-
-enhanced-resolve@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz#2937e2b8066cd0fe7ce0990a98f0d71a35189f66"
-  integrity sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==
-  dependencies:
-    graceful-fs "^4.1.2"
-    memory-fs "^0.5.0"
-    tapable "^1.0.0"
 
 enhanced-resolve@^4.3.0:
   version "4.3.0"
@@ -8039,7 +8030,7 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -8836,10 +8827,12 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-"serialize-javascript@>= 2.1.2", serialize-javascript@^2.1.2:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.0.0.tgz#492e489a2d77b7b804ad391a5f5d97870952548e"
-  integrity sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==
+"serialize-javascript@>= 3.1.0", serialize-javascript@^2.1.2:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-static@1.14.1:
   version "1.14.1"
@@ -10340,15 +10333,6 @@ watchpack@2.0.0-beta.13:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-watchpack@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.1.tgz#280da0a8718592174010c078c7585a74cd8cd0e2"
-  integrity sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==
-  dependencies:
-    chokidar "^2.1.8"
-    graceful-fs "^4.1.2"
-    neo-async "^2.5.0"
-
 watchpack@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.4.tgz#6e9da53b3c80bb2d6508188f5b200410866cd30b"
@@ -10388,7 +10372,7 @@ webpack-sources@1.4.3, webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-s
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.44.1:
+webpack@4.44.1, webpack@^4.41.5:
   version "4.44.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.1.tgz#17e69fff9f321b8f117d1fda714edfc0b939cc21"
   integrity sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
@@ -10415,35 +10399,6 @@ webpack@4.44.1:
     tapable "^1.1.3"
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
-    webpack-sources "^1.4.1"
-
-webpack@^4.41.5:
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
-  integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
-  dependencies:
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/wasm-edit" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.4.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.3"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.3"
-    watchpack "^1.6.1"
     webpack-sources "^1.4.1"
 
 whatwg-encoding@^1.0.5:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Dependabot reported an issue with the version of `serialize-javascript`,
 which we already had a resolution for but bumped it up to the next
 stable version that was requested to upgrade to.

 In the process, also removed a minor React warning around the `AltLang`
  component for unique keys.

### Changelog

**Changed**

- Updated resolution for `serialize-javascript`
- Updated version of IBM.com Library `@next` release
- Fixed minor React console error
